### PR TITLE
Added Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'kind/feature'
+      - 'kind/enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'kind/fix'
+      - 'kind/bugfix'
+      - 'kind/bug'
+  - title: '🧰 Maintenance'
+    labels: 
+      - 'kind/chore'
+      - 'area/ci'
+      - 'area/tests'
+  - title: 📖 Documentation
+    label: area/docs 
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## What's New
+  $CHANGES
+  
+  ## Contributors
+  
+  Thank you to our contributors for making this release possible:
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    # our release branch
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Udoka <UdokakuUgochukwu@gmail.com>

**Description**

This PR fixes issue: Add Release Drafter for the repository #24
Current Behavior
Each of the layer5 repositories needs releaseDrafter automation as had been done in the meshery project which takes care of drafting release notes.

Desired Behavior
Add ReleaseDrafter configuration yaml file & GitHub Action.

Action performed
Added the Github Action & configuration yaml file.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
