### PR TITLE
[#28] Fixing - Broken link for Welcome Celebration Message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -14,7 +14,7 @@ newPRWelcomeComment: >
 firstPRMergeComment: >
   Thanks for your contribution to the Layer5 community! :tada:
    
-  ![Congrats!](/.github/welcome/Layer5-celebration.png)
+  ![Congrats!](./welcome/Layer5-celebration.png)
 #--------------------------------------------------------------------------------
 # Configuration for request-info - https://github.com/behaviorbot/request-info
 # Comment to reply with


### PR DESCRIPTION
**Description**

Fixing Broken link to Welcome celebration image
`(../.github/welcome/Layer5-celebration.png)` to `(./welcome/Layer5-celebration.png)`

This PR fixes #28 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
